### PR TITLE
Node mock branch

### DIFF
--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -14,3 +14,4 @@ serde = "1"
 serde_json = "1"
 tokio = { version = "1", features = ["sync"] }
 uuid = { version = "1", features = ["v4"] }
+url = { version = "=2.5.0", default-features = false, features = ["serde"] }

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -152,4 +152,62 @@ impl Model {
 
         Some(())
     }
+
+    pub async fn insert_sender(&self, sender: Sender) -> Option<()> {
+        // Check device id and flow id in model
+        let devices = self.devices.read().await;
+        let flows = self.flows.read().await;
+        if !devices.contains_key(&sender.device_id) || !flows.contains_key(&sender.flow_id) {
+            return None;
+        }
+
+        let mut senders = self.senders.write().await;
+        senders.insert(sender.core.id, sender);
+
+        Some(())
+    }
+
+    pub async fn insert_flow(&self, flow: Flow) -> Option<()> {
+        // Check device id and source id in model
+        let devices = self.devices.read().await;
+        let sources = self.sources.read().await;
+        if !devices.contains_key(&flow.device_id) || !sources.contains_key(&flow.source_id) {
+            return None;
+        }
+
+        let mut flows = self.flows.write().await;
+        flows.insert(flow.core.id, flow);
+
+        Some(())
+    }
+
+    pub async fn remove_node(&self, id: &Uuid) -> Option<()> {
+        let mut nodes = self.nodes.write().await;
+        nodes.remove(id).map(|_| ())
+    }
+
+    pub async fn remove_device(&self, id: &Uuid) -> Option<()> {
+        let mut devices = self.devices.write().await;
+        devices.remove(id).map(|_| ())
+    }
+
+    pub async fn remove_source(&self, id: &Uuid) -> Option<()> {
+        let mut sources = self.sources.write().await;
+        sources.remove(id).map(|_| ())
+    }
+
+    pub async fn remove_sender(&self, id: &Uuid) -> Option<()> {
+        let mut senders = self.senders.write().await;
+        senders.remove(id).map(|_| ())
+    }
+
+    pub async fn remove_receiver(&self, id: &Uuid) -> Option<()> {
+        let mut receivers = self.receivers.write().await;
+        receivers.remove(id).map(|_| ())
+    }
+
+    pub async fn remove_flow(&self, id: &Uuid) -> Option<()> {
+        let mut flows = self.flows.write().await;
+        flows.remove(id).map(|_| ())
+    }
 }

--- a/model/src/resource/capabilities.rs
+++ b/model/src/resource/capabilities.rs
@@ -1,0 +1,36 @@
+use nmos_schema::is_04::v1_3_x::{
+    FlowAudioCodedGrainRate, FlowAudioCodedSampleRate, FlowVideoCodedGrainRate,
+};
+
+#[derive(Debug, Clone)]
+pub struct GrainRate {
+    pub denominator: Option<i64>,
+    pub numerator: i64,
+}
+
+impl Into<FlowVideoCodedGrainRate> for GrainRate {
+    fn into(self) -> FlowVideoCodedGrainRate {
+        FlowVideoCodedGrainRate {
+            denominator: self.denominator,
+            numerator: self.numerator,
+        }
+    }
+}
+
+impl Into<FlowAudioCodedGrainRate> for GrainRate {
+    fn into(self) -> FlowAudioCodedGrainRate {
+        FlowAudioCodedGrainRate {
+            denominator: self.denominator,
+            numerator: self.numerator,
+        }
+    }
+}
+
+impl Into<FlowAudioCodedSampleRate> for GrainRate {
+    fn into(self) -> FlowAudioCodedSampleRate {
+        FlowAudioCodedSampleRate {
+            denominator: self.denominator,
+            numerator: self.numerator,
+        }
+    }
+}

--- a/model/src/resource/device.rs
+++ b/model/src/resource/device.rs
@@ -10,7 +10,7 @@ use crate::{
     version::{is_04::V1_0, is_04::V1_3, APIVersion},
 };
 
-use super::{ResourceCore, ResourceCoreBuilder};
+use super::{Registerable, ResourceCore, ResourceCoreBuilder};
 
 macro_rules! registration_request {
     ($value:expr, $version:ident) => {
@@ -116,8 +116,14 @@ impl Device {
             _ => panic!("Unsupported API"),
         }
     }
+}
 
-    pub fn registration_request(&self, api: &APIVersion) -> serde_json::Value {
+impl Registerable for Device {
+    fn registry_path(&self) -> String {
+        format!("devices/{}", self.core.id)
+    }
+
+    fn registration_request(&self, api: &APIVersion) -> serde_json::Value {
         match self.to_json(api) {
             DeviceJson::V1_0(json) => registration_request!(json, v1_0_x),
             DeviceJson::V1_3(json) => registration_request!(json, v1_3_x),

--- a/model/src/resource/device.rs
+++ b/model/src/resource/device.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{collections::BTreeMap, fmt};
 
 use nmos_schema::is_04;
 use serde::Serialize;
@@ -6,7 +6,7 @@ use uuid::Uuid;
 
 use crate::{
     resource::Node,
-    version::{is_04::V1_0, APIVersion},
+    version::{is_04::V1_0, is_04::V1_3, APIVersion},
 };
 
 use super::{ResourceCore, ResourceCoreBuilder};
@@ -92,6 +92,26 @@ impl Device {
                     receivers,
                 })
             }
+            V1_3 => {
+                // Senders
+                let senders = self.senders.iter().map(ToString::to_string).collect();
+
+                // Receivers
+                let receivers = self.receivers.iter().map(ToString::to_string).collect();
+
+                DeviceJson::V1_3(is_04::v1_3_x::Device {
+                    id: self.core.id.to_string(),
+                    version: self.core.version.to_string(),
+                    label: self.core.label.clone(),
+                    type_: is_04::v1_3_x::DeviceType::Variant0(self.type_.to_string().into()),
+                    node_id: self.node_id.to_string(),
+                    senders,
+                    receivers,
+                    tags: BTreeMap::new(),
+                    description: "".to_string(),
+                    controls: vec![],
+                })
+            }
             _ => panic!("Unsupported API"),
         }
     }
@@ -101,4 +121,5 @@ impl Device {
 #[serde(untagged)]
 pub enum DeviceJson {
     V1_0(is_04::v1_0_x::Device),
+    V1_3(is_04::v1_3_x::Device),
 }

--- a/model/src/resource/device.rs
+++ b/model/src/resource/device.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, fmt};
+use std::fmt;
 
 use nmos_schema::is_04;
 use serde::Serialize;
@@ -107,7 +107,7 @@ impl Device {
                     node_id: self.node_id.to_string(),
                     senders,
                     receivers,
-                    tags: BTreeMap::new(),
+                    tags: self.core.tags_json(),
                     description: "".to_string(),
                     controls: vec![],
                 })

--- a/model/src/resource/device.rs
+++ b/model/src/resource/device.rs
@@ -46,7 +46,7 @@ pub struct DeviceBuilder {
 }
 
 impl DeviceBuilder {
-    pub fn new<S: Into<String>>(label: S, node: &Node, device_type: DeviceType) -> Self {
+    pub fn new(label: impl Into<String>, node: &Node, device_type: DeviceType) -> Self {
         DeviceBuilder {
             core: ResourceCoreBuilder::new(label),
             type_: device_type,
@@ -76,8 +76,8 @@ pub struct Device {
 }
 
 impl Device {
-    pub fn builder<S: Into<String>>(
-        label: S,
+    pub fn builder(
+        label: impl Into<String>,
         node: &Node,
         device_type: DeviceType,
     ) -> DeviceBuilder {
@@ -140,11 +140,11 @@ impl Into<v1_3_x::Device> for Device {
             label: self.core.label.clone(),
             type_: v1_3_x::DeviceType::Variant0(self.type_.to_string().into()),
             node_id: self.node_id.to_string(),
+            tags: self.core.tags_json(),
+            description: self.core.description.clone(),
+            controls: Vec::default(),
             senders,
             receivers,
-            tags: self.core.tags_json(),
-            description: "".to_string(),
-            controls: vec![],
         }
     }
 }

--- a/model/src/resource/device.rs
+++ b/model/src/resource/device.rs
@@ -87,8 +87,8 @@ impl Device {
     #[must_use]
     pub fn to_json(&self, api: &APIVersion) -> DeviceJson {
         match *api {
-            V1_0 => DeviceJson::V1_0((*self).clone().into()),
-            V1_3 => DeviceJson::V1_3((*self).clone().into()),
+            V1_0 => DeviceJson::V1_0(self.clone().into()),
+            V1_3 => DeviceJson::V1_3(self.clone().into()),
             _ => panic!("Unsupported API"),
         }
     }

--- a/model/src/resource/flow.rs
+++ b/model/src/resource/flow.rs
@@ -84,20 +84,7 @@ impl Flow {
     #[must_use]
     pub fn to_json(&self, api: &APIVersion) -> FlowJson {
         match *api {
-            V1_0 => {
-                let parents = self.parents.iter().map(ToString::to_string).collect();
-
-                FlowJson::V1_0(v1_0_x::Flow {
-                    id: self.core.id.to_string(),
-                    version: self.core.version.to_string(),
-                    label: self.core.label.clone(),
-                    description: self.core.description.clone(),
-                    format: self.format.to_string(),
-                    tags: self.core.tags_json(),
-                    source_id: self.source_id.to_string(),
-                    parents,
-                })
-            }
+            V1_0 => FlowJson::V1_0((*self).clone().into()),
             V1_3 => FlowJson::V1_3((*self).clone().into()),
             _ => panic!("Unsupported API"),
         }
@@ -122,6 +109,23 @@ impl Registerable for Flow {
 pub enum FlowJson {
     V1_0(v1_0_x::Flow),
     V1_3(v1_3_x::Flow),
+}
+
+impl Into<v1_0_x::Flow> for Flow {
+    fn into(self) -> v1_0_x::Flow {
+        let parents = self.parents.iter().map(ToString::to_string).collect();
+
+        v1_0_x::Flow {
+            id: self.core.id.to_string(),
+            version: self.core.version.to_string(),
+            label: self.core.label.clone(),
+            description: self.core.description.clone(),
+            format: self.format.to_string(),
+            tags: self.core.tags_json(),
+            source_id: self.source_id.to_string(),
+            parents,
+        }
+    }
 }
 
 impl Into<v1_3_x::Flow> for Flow {

--- a/model/src/resource/flow.rs
+++ b/model/src/resource/flow.rs
@@ -8,7 +8,7 @@ use crate::{
     version::{is_04::V1_0, is_04::V1_3, APIVersion},
 };
 
-use super::{Device, ResourceCore, ResourceCoreBuilder};
+use super::{Device, Registerable, ResourceCore, ResourceCoreBuilder};
 
 macro_rules! registration_request {
     ($value:expr, $version:ident) => {
@@ -102,8 +102,14 @@ impl Flow {
             _ => panic!("Unsupported API"),
         }
     }
+}
 
-    pub fn registration_request(&self, api: &APIVersion) -> serde_json::Value {
+impl Registerable for Flow {
+    fn registry_path(&self) -> String {
+        format!("flows/{}", self.core.id)
+    }
+
+    fn registration_request(&self, api: &APIVersion) -> serde_json::Value {
         match self.to_json(api) {
             FlowJson::V1_0(json) => registration_request!(json, v1_0_x),
             FlowJson::V1_3(json) => registration_request!(json, v1_3_x),

--- a/model/src/resource/flow.rs
+++ b/model/src/resource/flow.rs
@@ -134,8 +134,8 @@ impl Flow {
     #[must_use]
     pub fn to_json(&self, api: &APIVersion) -> FlowJson {
         match *api {
-            V1_0 => FlowJson::V1_0((*self).clone().into()),
-            V1_3 => FlowJson::V1_3((*self).clone().into()),
+            V1_0 => FlowJson::V1_0(self.clone().into()),
+            V1_3 => FlowJson::V1_3(self.clone().into()),
             _ => panic!("Unsupported API"),
         }
     }

--- a/model/src/resource/flow.rs
+++ b/model/src/resource/flow.rs
@@ -37,7 +37,7 @@ pub struct FlowBuilder {
 }
 
 impl FlowBuilder {
-    pub fn new<S: Into<String>>(label: S, source: &Source, device: &Device) -> Self {
+    pub fn new(label: impl Into<String>, source: &Source, device: &Device) -> Self {
         FlowBuilder {
             core: ResourceCoreBuilder::new(label),
             format: source.format,
@@ -46,14 +46,14 @@ impl FlowBuilder {
             parents: Vec::new(),
             frame_height: 640,
             frame_width: 480,
-            media_type: "".into(),
-            colorspace: "".into(),
+            media_type: String::default(),
+            colorspace: String::default(),
             grain_rate: None,
             sample_rate: None,
         }
     }
 
-    pub fn with_description<S: Into<String>>(mut self, description: S) -> Self {
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
         self.core = self.core.description(description);
         self
     }
@@ -127,7 +127,7 @@ pub struct Flow {
 }
 
 impl Flow {
-    pub fn builder<S: Into<String>>(label: S, source: &Source, device: &Device) -> FlowBuilder {
+    pub fn builder(label: impl Into<String>, source: &Source, device: &Device) -> FlowBuilder {
         FlowBuilder::new(label, source, device)
     }
 

--- a/model/src/resource/mod.rs
+++ b/model/src/resource/mod.rs
@@ -31,6 +31,7 @@ pub enum Transport {
     RtpUnicast,
     RtpMulticast,
     Dash,
+    Http,
 }
 
 impl fmt::Display for Format {
@@ -50,6 +51,7 @@ impl fmt::Display for Transport {
             Transport::RtpUnicast => write!(f, "urn:x-nmos:transport:rtp.ucast"),
             Transport::RtpMulticast => write!(f, "urn:x-nmos:transport:rtp.mcast"),
             Transport::Dash => write!(f, "urn:x-nmos:transport:dash"),
+            Transport::Http => write!(f, "urn:x-nmos:transport:http"),
         }
     }
 }

--- a/model/src/resource/mod.rs
+++ b/model/src/resource/mod.rs
@@ -11,6 +11,7 @@ pub use source::{Source, SourceBuilder, SourceJson};
 
 use crate::{tai::TaiTime, version::APIVersion};
 
+pub mod capabilities;
 pub mod device;
 pub mod flow;
 pub mod node;

--- a/model/src/resource/mod.rs
+++ b/model/src/resource/mod.rs
@@ -18,7 +18,7 @@ pub mod receiver;
 pub mod sender;
 pub mod source;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Format {
     Video,
     Audio,

--- a/model/src/resource/mod.rs
+++ b/model/src/resource/mod.rs
@@ -9,7 +9,7 @@ pub use receiver::{Receiver, ReceiverBuilder, ReceiverJson};
 pub use sender::{Sender, SenderBuilder, SenderJson};
 pub use source::{Source, SourceBuilder, SourceJson};
 
-use crate::tai::TaiTime;
+use crate::{tai::TaiTime, version::APIVersion};
 
 pub mod device;
 pub mod flow;
@@ -32,6 +32,11 @@ pub enum Transport {
     RtpMulticast,
     Dash,
     Http,
+}
+
+pub trait Registerable {
+    fn registry_path(&self) -> String;
+    fn registration_request(&self, api: &APIVersion) -> serde_json::Value;
 }
 
 impl fmt::Display for Format {

--- a/model/src/resource/mod.rs
+++ b/model/src/resource/mod.rs
@@ -11,12 +11,12 @@ pub use source::{Source, SourceBuilder, SourceJson};
 
 use crate::tai::TaiTime;
 
-mod device;
-mod flow;
-mod node;
-mod receiver;
-mod sender;
-mod source;
+pub mod device;
+pub mod flow;
+pub mod node;
+pub mod receiver;
+pub mod sender;
+pub mod source;
 
 #[derive(Debug, Clone, Copy)]
 pub enum Format {

--- a/model/src/resource/mod.rs
+++ b/model/src/resource/mod.rs
@@ -101,7 +101,7 @@ impl ResourceCoreBuilder {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ResourceCore {
     pub id: Uuid,
     pub version: TaiTime,
@@ -113,6 +113,16 @@ pub struct ResourceCore {
 impl ResourceCore {
     pub fn builder<S: Into<String>>(label: S) -> ResourceCoreBuilder {
         ResourceCoreBuilder::new(label)
+    }
+
+    pub fn tags_json(&self) -> BTreeMap<String, serde_json::Value> {
+        self.tags
+            .iter()
+            .fold(BTreeMap::new(), |mut map, (key, array)| {
+                let value = serde_json::Value::from(array.clone());
+                map.insert(key.clone(), value);
+                map
+            })
     }
 }
 

--- a/model/src/resource/node.rs
+++ b/model/src/resource/node.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use nmos_schema::is_04;
 use serde::Serialize;
 
-use crate::version::{is_04::V1_0, APIVersion};
+use crate::version::{is_04::V1_0, is_04::V1_3, APIVersion};
 
 use super::{ResourceCore, ResourceCoreBuilder};
 
@@ -83,6 +83,35 @@ impl Node {
                     services,
                 })
             }
+            V1_3 => {
+                let services = self
+                    .services
+                    .iter()
+                    .map(|service| is_04::v1_3_x::NodeItemServices {
+                        authorization: None,
+                        href: service.href.clone(),
+                        type_: service.type_.clone(),
+                    })
+                    .collect();
+
+                NodeJson::V1_3(is_04::v1_3_x::Node {
+                    description: "".to_string(),
+                    id: self.core.id.to_string(),
+                    version: self.core.version.to_string(),
+                    label: self.core.label.clone(),
+                    href: self.href.clone(),
+                    hostname: self.hostname.clone(),
+                    caps: BTreeMap::default(),
+                    services,
+                    clocks: vec![],
+                    interfaces: vec![],
+                    api: nmos_schema::is_04::v1_3_x::NodeApi {
+                        versions: vec![V1_3.to_string()],
+                        endpoints: vec![],
+                    },
+                    tags: BTreeMap::new(),
+                })
+            }
             _ => panic!("Unsupported API"),
         }
     }
@@ -92,4 +121,5 @@ impl Node {
 #[serde(untagged)]
 pub enum NodeJson {
     V1_0(is_04::v1_0_x::Node),
+    V1_3(is_04::v1_3_x::Node),
 }

--- a/model/src/resource/node.rs
+++ b/model/src/resource/node.rs
@@ -95,21 +95,26 @@ impl Node {
                     .collect();
 
                 NodeJson::V1_3(is_04::v1_3_x::Node {
-                    description: "".to_string(),
+                    description: self.core.description.to_string(),
                     id: self.core.id.to_string(),
                     version: self.core.version.to_string(),
                     label: self.core.label.clone(),
                     href: self.href.clone(),
                     hostname: self.hostname.clone(),
                     caps: BTreeMap::default(),
-                    services,
-                    clocks: vec![],
+                    clocks: vec![serde_json::json!({"name": "clk0", "ref_type": "internal"})],
                     interfaces: vec![],
                     api: nmos_schema::is_04::v1_3_x::NodeApi {
                         versions: vec![V1_3.to_string()],
-                        endpoints: vec![],
+                        endpoints: vec![is_04::v1_3_x::NodeApiItemEndpoints {
+                            host: serde_json::json!("localhost".to_string()),
+                            port: 8088,
+                            protocol: "http".into(),
+                            authorization: Some(false),
+                        }],
                     },
                     tags: self.core.tags_json(),
+                    services,
                 })
             }
             _ => panic!("Unsupported API"),

--- a/model/src/resource/node.rs
+++ b/model/src/resource/node.rs
@@ -109,7 +109,7 @@ impl Node {
                         versions: vec![V1_3.to_string()],
                         endpoints: vec![],
                     },
-                    tags: BTreeMap::new(),
+                    tags: self.core.tags_json(),
                 })
             }
             _ => panic!("Unsupported API"),

--- a/model/src/resource/node.rs
+++ b/model/src/resource/node.rs
@@ -34,7 +34,7 @@ pub struct NodeBuilder {
 }
 
 impl NodeBuilder {
-    pub fn new<S: Into<String>>(label: S, href: S) -> Self {
+    pub fn new(label: impl Into<String>, href: impl Into<String>) -> Self {
         NodeBuilder {
             core: ResourceCoreBuilder::new(label),
             href: href.into(),
@@ -68,7 +68,7 @@ pub struct Node {
 }
 
 impl Node {
-    pub fn builder<S: Into<String>>(label: S, href: S) -> NodeBuilder {
+    pub fn builder(label: impl Into<String>, href: impl Into<String>) -> NodeBuilder {
         NodeBuilder::new(label, href)
     }
 

--- a/model/src/resource/node.rs
+++ b/model/src/resource/node.rs
@@ -6,7 +6,7 @@ use serde_json::json;
 
 use crate::version::{is_04::V1_0, is_04::V1_3, APIVersion};
 
-use super::{ResourceCore, ResourceCoreBuilder};
+use super::{Registerable, ResourceCore, ResourceCoreBuilder};
 
 macro_rules! registration_request {
     ($value:expr, $version:ident) => {
@@ -132,8 +132,14 @@ impl Node {
             _ => panic!("Unsupported API"),
         }
     }
+}
 
-    pub fn registration_request(&self, api: &APIVersion) -> serde_json::Value {
+impl Registerable for Node {
+    fn registry_path(&self) -> String {
+        format!("/nodes/{}", self.core.id)
+    }
+
+    fn registration_request(&self, api: &APIVersion) -> serde_json::Value {
         match self.to_json(api) {
             NodeJson::V1_0(json) => registration_request!(json, v1_0_x),
             NodeJson::V1_3(json) => registration_request!(json, v1_3_x),

--- a/model/src/resource/node.rs
+++ b/model/src/resource/node.rs
@@ -75,8 +75,8 @@ impl Node {
     #[must_use]
     pub fn to_json(&self, api: &APIVersion) -> NodeJson {
         match *api {
-            V1_0 => NodeJson::V1_0((*self).clone().into()),
-            V1_3 => NodeJson::V1_3((*self).clone().into()),
+            V1_0 => NodeJson::V1_0(self.clone().into()),
+            V1_3 => NodeJson::V1_3(self.clone().into()),
             _ => panic!("Unsupported API"),
         }
     }

--- a/model/src/resource/node.rs
+++ b/model/src/resource/node.rs
@@ -40,7 +40,7 @@ impl NodeBuilder {
     pub fn build(self) -> Node {
         Node {
             core: self.core.build(),
-            href: self.href,
+            href: self.href.parse().unwrap(),
             hostname: self.hostname,
             services: self.services,
         }
@@ -50,7 +50,7 @@ impl NodeBuilder {
 #[derive(Debug)]
 pub struct Node {
     pub core: ResourceCore,
-    pub href: String,
+    pub href: url::Url,
     pub hostname: Option<String>,
     pub services: Vec<NodeService>,
 }
@@ -77,7 +77,7 @@ impl Node {
                     id: self.core.id.to_string(),
                     version: self.core.version.to_string(),
                     label: self.core.label.clone(),
-                    href: self.href.clone(),
+                    href: self.href.to_string(),
                     hostname: self.hostname.clone(),
                     caps: BTreeMap::default(),
                     services,
@@ -99,7 +99,7 @@ impl Node {
                     id: self.core.id.to_string(),
                     version: self.core.version.to_string(),
                     label: self.core.label.clone(),
-                    href: self.href.clone(),
+                    href: self.href.to_string(),
                     hostname: self.hostname.clone(),
                     caps: BTreeMap::default(),
                     clocks: vec![serde_json::json!({"name": "clk0", "ref_type": "internal"})],
@@ -107,8 +107,8 @@ impl Node {
                     api: nmos_schema::is_04::v1_3_x::NodeApi {
                         versions: vec![V1_3.to_string()],
                         endpoints: vec![is_04::v1_3_x::NodeApiItemEndpoints {
-                            host: serde_json::json!("localhost".to_string()),
-                            port: 8088,
+                            host: serde_json::json!(self.href.host_str().unwrap()),
+                            port: self.href.port().unwrap() as i64,
                             protocol: "http".into(),
                             authorization: Some(false),
                         }],

--- a/model/src/resource/receiver.rs
+++ b/model/src/resource/receiver.rs
@@ -10,7 +10,7 @@ use crate::{
     version::{is_04::V1_0, is_04::V1_3, APIVersion},
 };
 
-use super::{ResourceCore, ResourceCoreBuilder};
+use super::{Registerable, ResourceCore, ResourceCoreBuilder};
 
 macro_rules! registration_request {
     ($value:expr, $version:ident) => {
@@ -118,8 +118,14 @@ impl Receiver {
             _ => panic!("Unsupported API"),
         }
     }
+}
 
-    pub fn registration_request(&self, api: &APIVersion) -> serde_json::Value {
+impl Registerable for Receiver {
+    fn registry_path(&self) -> String {
+        format!("receivers/{}", self.core.id)
+    }
+
+    fn registration_request(&self, api: &APIVersion) -> serde_json::Value {
         match self.to_json(api) {
             ReceiverJson::V1_0(json) => registration_request!(json, v1_0_x),
             ReceiverJson::V1_3(json) => registration_request!(json, v1_3_x),

--- a/model/src/resource/receiver.rs
+++ b/model/src/resource/receiver.rs
@@ -96,24 +96,7 @@ impl Receiver {
     #[must_use]
     pub fn to_json(&self, api: &APIVersion) -> ReceiverJson {
         match *api {
-            V1_0 => {
-                let subscription = v1_0_x::ReceiverSubscription {
-                    sender_id: self.subscription.map(|s| s.to_string()),
-                };
-
-                ReceiverJson::V1_0(v1_0_x::Receiver {
-                    id: self.core.id.to_string(),
-                    version: self.core.version.to_string(),
-                    label: self.core.label.clone(),
-                    description: self.core.description.clone(),
-                    format: self.format.to_string(),
-                    caps: BTreeMap::default(),
-                    tags: self.core.tags_json(),
-                    device_id: self.device_id.to_string(),
-                    transport: self.transport.to_string(),
-                    subscription,
-                })
-            }
+            V1_0 => ReceiverJson::V1_0((*self).clone().into()),
             V1_3 => ReceiverJson::V1_3((*self).clone().into()),
             _ => panic!("Unsupported API"),
         }
@@ -140,8 +123,29 @@ pub enum ReceiverJson {
     V1_3(v1_3_x::Receiver),
 }
 
-impl Into<nmos_schema::is_04::v1_3_x::Receiver> for Receiver {
-    fn into(self) -> nmos_schema::is_04::v1_3_x::Receiver {
+impl Into<v1_0_x::Receiver> for Receiver {
+    fn into(self) -> v1_0_x::Receiver {
+        let subscription = v1_0_x::ReceiverSubscription {
+            sender_id: self.subscription.map(|s| s.to_string()),
+        };
+
+        v1_0_x::Receiver {
+            id: self.core.id.to_string(),
+            version: self.core.version.to_string(),
+            label: self.core.label.clone(),
+            description: self.core.description.clone(),
+            format: self.format.to_string(),
+            caps: BTreeMap::default(),
+            tags: self.core.tags_json(),
+            device_id: self.device_id.to_string(),
+            transport: self.transport.to_string(),
+            subscription,
+        }
+    }
+}
+
+impl Into<v1_3_x::Receiver> for Receiver {
+    fn into(self) -> v1_3_x::Receiver {
         let tags = self.core.tags_json();
         let interface_bindings: Vec<std::string::String> = vec![];
         let id = self.core.id.to_string();
@@ -158,9 +162,8 @@ impl Into<nmos_schema::is_04::v1_3_x::Receiver> for Receiver {
                     sender_id: self.subscription.map(|s| s.to_string()),
                 };
                 let caps = v1_3_x::ReceiverVideoCaps { media_types: None };
-                let transport = nmos_schema::is_04::v1_3_x::ReceiverVideoTransport::Variant0(
-                    self.transport.to_string().into(),
-                );
+                let transport =
+                    v1_3_x::ReceiverVideoTransport::Variant0(self.transport.to_string().into());
                 v1_3_x::Receiver::Variant0(v1_3_x::ReceiverVideo {
                     interface_bindings,
                     id,
@@ -184,9 +187,8 @@ impl Into<nmos_schema::is_04::v1_3_x::Receiver> for Receiver {
                     // TODO: implement caps
                     media_types: None,
                 };
-                let transport = nmos_schema::is_04::v1_3_x::ReceiverAudioTransport::Variant0(
-                    self.transport.to_string().into(),
-                );
+                let transport =
+                    v1_3_x::ReceiverAudioTransport::Variant0(self.transport.to_string().into());
                 v1_3_x::Receiver::Variant1(v1_3_x::ReceiverAudio {
                     interface_bindings,
                     id,
@@ -206,9 +208,8 @@ impl Into<nmos_schema::is_04::v1_3_x::Receiver> for Receiver {
                     active: false,
                     sender_id: self.subscription.map(|s| s.to_string()),
                 };
-                let transport = nmos_schema::is_04::v1_3_x::ReceiverDataTransport::Variant0(
-                    self.transport.to_string().into(),
-                );
+                let transport =
+                    v1_3_x::ReceiverDataTransport::Variant0(self.transport.to_string().into());
                 let caps = v1_3_x::ReceiverDataCaps {
                     // TODO: implement caps
                     media_types: None,

--- a/model/src/resource/receiver.rs
+++ b/model/src/resource/receiver.rs
@@ -62,7 +62,7 @@ impl ReceiverBuilder {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Receiver {
     pub core: ResourceCore,
     pub format: Format,
@@ -85,16 +85,6 @@ impl Receiver {
     pub fn to_json(&self, api: &APIVersion) -> ReceiverJson {
         match *api {
             V1_0 => {
-                let tags = self
-                    .core
-                    .tags
-                    .iter()
-                    .fold(BTreeMap::new(), |mut map, (key, array)| {
-                        let value = serde_json::Value::from(array.clone());
-                        map.insert(key.clone(), value);
-                        map
-                    });
-
                 let subscription = is_04::v1_0_x::ReceiverSubscription {
                     sender_id: self.subscription.map(|s| s.to_string()),
                 };
@@ -106,49 +96,13 @@ impl Receiver {
                     description: self.core.description.clone(),
                     format: self.format.to_string(),
                     caps: BTreeMap::default(),
-                    tags,
+                    tags: self.core.tags_json(),
                     device_id: self.device_id.to_string(),
                     transport: self.transport.to_string(),
                     subscription,
                 })
             }
-            V1_3 => {
-                let tags = self
-                    .core
-                    .tags
-                    .iter()
-                    .fold(BTreeMap::new(), |mut map, (key, array)| {
-                        let value = serde_json::Value::from(array.clone());
-                        map.insert(key.clone(), value);
-                        map
-                    });
-
-                let subscription = is_04::v1_3_x::ReceiverVideoSubscription {
-                    active: false,
-                    sender_id: self.subscription.map(|s| s.to_string()),
-                };
-
-                ReceiverJson::V1_3(is_04::v1_3_x::Receiver::Variant0(
-                    is_04::v1_3_x::ReceiverVideo {
-                        interface_bindings: vec![],
-                        id: self.core.id.to_string(),
-                        version: self.core.version.to_string(),
-                        label: self.core.label.clone(),
-                        description: self.core.description.clone(),
-                        format: self.format.to_string(),
-                        caps: is_04::v1_3_x::ReceiverVideoCaps {
-                            // TODO: implement caps
-                            media_types: None,
-                        },
-                        tags,
-                        device_id: self.device_id.to_string(),
-                        transport: nmos_schema::is_04::v1_3_x::ReceiverVideoTransport::Variant0(
-                            self.transport.to_string().into(),
-                        ),
-                        subscription,
-                    },
-                ))
-            }
+            V1_3 => ReceiverJson::V1_3((*self).clone().into()),
             _ => panic!("Unsupported API"),
         }
     }
@@ -159,4 +113,97 @@ impl Receiver {
 pub enum ReceiverJson {
     V1_0(is_04::v1_0_x::Receiver),
     V1_3(is_04::v1_3_x::Receiver),
+}
+
+impl Into<nmos_schema::is_04::v1_3_x::Receiver> for Receiver {
+    fn into(self) -> nmos_schema::is_04::v1_3_x::Receiver {
+        let tags = self.core.tags_json();
+        let interface_bindings: Vec<std::string::String> = vec![];
+        let id = self.core.id.to_string();
+        let version = self.core.version.to_string();
+        let label = self.core.label.clone();
+        let description = self.core.description.clone();
+        let format = self.format.to_string();
+        let device_id = self.device_id.to_string();
+
+        match self.format {
+            Format::Video => {
+                let subscription = is_04::v1_3_x::ReceiverVideoSubscription {
+                    active: false,
+                    sender_id: self.subscription.map(|s| s.to_string()),
+                };
+                let caps = is_04::v1_3_x::ReceiverVideoCaps { media_types: None };
+                // TODO: figure out which one is correct
+                let transport = nmos_schema::is_04::v1_3_x::ReceiverVideoTransport::Variant0(
+                    self.transport.to_string().into(),
+                );
+                is_04::v1_3_x::Receiver::Variant0(is_04::v1_3_x::ReceiverVideo {
+                    interface_bindings,
+                    id,
+                    version,
+                    tags,
+                    label,
+                    description,
+                    format,
+                    device_id,
+                    caps,
+                    subscription,
+                    transport,
+                })
+            }
+            Format::Audio => {
+                let subscription = is_04::v1_3_x::ReceiverAudioSubscription {
+                    active: false,
+                    sender_id: self.subscription.map(|s| s.to_string()),
+                };
+                let caps = is_04::v1_3_x::ReceiverAudioCaps {
+                    // TODO: implement caps
+                    media_types: None,
+                };
+                let transport = nmos_schema::is_04::v1_3_x::ReceiverAudioTransport::Variant0(
+                    self.transport.to_string().into(),
+                );
+                is_04::v1_3_x::Receiver::Variant1(is_04::v1_3_x::ReceiverAudio {
+                    interface_bindings,
+                    id,
+                    version,
+                    tags,
+                    label,
+                    description,
+                    format,
+                    device_id,
+                    caps,
+                    subscription,
+                    transport,
+                })
+            }
+            Format::Data => {
+                let subscription = is_04::v1_3_x::ReceiverDataSubscription {
+                    active: false,
+                    sender_id: self.subscription.map(|s| s.to_string()),
+                };
+                let transport = nmos_schema::is_04::v1_3_x::ReceiverDataTransport::Variant0(
+                    self.transport.to_string().into(),
+                );
+                let caps = is_04::v1_3_x::ReceiverDataCaps {
+                    // TODO: implement caps
+                    media_types: None,
+                    event_types: None,
+                };
+                is_04::v1_3_x::Receiver::Variant2(is_04::v1_3_x::ReceiverData {
+                    interface_bindings,
+                    id,
+                    version,
+                    tags,
+                    label,
+                    description,
+                    format,
+                    device_id,
+                    subscription,
+                    transport,
+                    caps,
+                })
+            }
+        }
+    }
 }

--- a/model/src/resource/receiver.rs
+++ b/model/src/resource/receiver.rs
@@ -96,8 +96,8 @@ impl Receiver {
     #[must_use]
     pub fn to_json(&self, api: &APIVersion) -> ReceiverJson {
         match *api {
-            V1_0 => ReceiverJson::V1_0((*self).clone().into()),
-            V1_3 => ReceiverJson::V1_3((*self).clone().into()),
+            V1_0 => ReceiverJson::V1_0(self.clone().into()),
+            V1_3 => ReceiverJson::V1_3(self.clone().into()),
             _ => panic!("Unsupported API"),
         }
     }

--- a/model/src/resource/receiver.rs
+++ b/model/src/resource/receiver.rs
@@ -33,8 +33,8 @@ pub struct ReceiverBuilder {
 }
 
 impl ReceiverBuilder {
-    pub fn new<S: Into<String>>(
-        label: S,
+    pub fn new(
+        label: impl Into<String>,
         device: &Device,
         format: Format,
         transport: Transport,
@@ -84,8 +84,8 @@ pub struct Receiver {
 }
 
 impl Receiver {
-    pub fn builder<S: Into<String>>(
-        label: S,
+    pub fn builder(
+        label: impl Into<String>,
         device: &Device,
         format: Format,
         transport: Transport,

--- a/model/src/resource/sender.rs
+++ b/model/src/resource/sender.rs
@@ -121,20 +121,6 @@ impl Sender {
                 })
             }
             V1_3 => {
-                let tags =
-                    if self.core.tags.is_empty() {
-                        None
-                    } else {
-                        Some(self.core.tags.iter().fold(
-                            BTreeMap::new(),
-                            |mut map, (key, array)| {
-                                let value = serde_json::Value::from(array.clone());
-                                map.insert(key.clone(), value);
-                                map
-                            },
-                        ))
-                    };
-
                 SenderJson::V1_3(is_04::v1_3_x::Sender {
                     interface_bindings: vec![],
                     // TODO: implement caps
@@ -144,7 +130,7 @@ impl Sender {
                     label: self.core.label.clone(),
                     description: self.core.description.clone(),
                     flow_id: Some(self.flow_id.to_string()),
-                    tags: tags.unwrap(),
+                    tags: self.core.tags_json(),
                     device_id: self.device_id.to_string(),
                     manifest_href: Some(self.manifest_href.clone()),
                     subscription: nmos_schema::is_04::v1_3_x::SenderSubscription {

--- a/model/src/resource/sender.rs
+++ b/model/src/resource/sender.rs
@@ -118,7 +118,7 @@ impl Sender {
             }),
             V1_3 => {
                 SenderJson::V1_3(v1_3_x::Sender {
-                    interface_bindings: vec!["default".into()],
+                    interface_bindings: vec![],
                     // TODO: implement caps
                     caps: None,
                     id: self.core.id.to_string(),

--- a/model/src/resource/sender.rs
+++ b/model/src/resource/sender.rs
@@ -107,8 +107,8 @@ impl Sender {
     #[must_use]
     pub fn to_json(&self, api: &APIVersion) -> SenderJson {
         match *api {
-            V1_0 => SenderJson::V1_0((*self).clone().into()),
-            V1_3 => SenderJson::V1_3((*self).clone().into()),
+            V1_0 => SenderJson::V1_0(self.clone().into()),
+            V1_3 => SenderJson::V1_3(self.clone().into()),
             _ => panic!("Unsupported API"),
         }
     }

--- a/model/src/resource/sender.rs
+++ b/model/src/resource/sender.rs
@@ -122,7 +122,7 @@ impl Sender {
             }
             V1_3 => {
                 SenderJson::V1_3(is_04::v1_3_x::Sender {
-                    interface_bindings: vec![],
+                    interface_bindings: vec!["default".into()],
                     // TODO: implement caps
                     caps: None,
                     id: self.core.id.to_string(),
@@ -132,7 +132,7 @@ impl Sender {
                     flow_id: Some(self.flow_id.to_string()),
                     tags: self.core.tags_json(),
                     device_id: self.device_id.to_string(),
-                    manifest_href: Some(self.manifest_href.clone()),
+                    manifest_href: None,
                     subscription: nmos_schema::is_04::v1_3_x::SenderSubscription {
                         active: false,
                         receiver_id: None,

--- a/model/src/resource/sender.rs
+++ b/model/src/resource/sender.rs
@@ -13,7 +13,7 @@ use crate::{
     },
 };
 
-use super::{ResourceCore, ResourceCoreBuilder};
+use super::{Registerable, ResourceCore, ResourceCoreBuilder};
 
 macro_rules! registration_request {
     ($value:expr, $version:ident) => {
@@ -139,8 +139,14 @@ impl Sender {
             _ => panic!("Unsupported API"),
         }
     }
+}
 
-    pub fn registration_request(&self, api: &APIVersion) -> serde_json::Value {
+impl Registerable for Sender {
+    fn registry_path(&self) -> String {
+        format!("senders/{}", self.core.id)
+    }
+
+    fn registration_request(&self, api: &APIVersion) -> serde_json::Value {
         match self.to_json(api) {
             SenderJson::V1_0(json) => registration_request!(json, v1_0_x),
             SenderJson::V1_3(json) => registration_request!(json, v1_3_x),

--- a/model/src/resource/sender.rs
+++ b/model/src/resource/sender.rs
@@ -36,8 +36,8 @@ pub struct SenderBuilder {
 }
 
 impl SenderBuilder {
-    pub fn new<S: Into<String>>(
-        label: S,
+    pub fn new(
+        label: impl Into<String>,
         device: &Device,
         flow: &Flow,
         transport: Transport,
@@ -95,8 +95,8 @@ pub struct Sender {
 }
 
 impl Sender {
-    pub fn builder<S: Into<String>>(
-        label: S,
+    pub fn builder(
+        label: impl Into<String>,
         device: &Device,
         flow: &Flow,
         transport: Transport,

--- a/model/src/resource/sender.rs
+++ b/model/src/resource/sender.rs
@@ -1,4 +1,4 @@
-use std::vec;
+use std::{collections::BTreeMap, vec};
 
 use nmos_schema::is_04::{v1_0_x, v1_3_x};
 use serde::Serialize;
@@ -79,6 +79,7 @@ impl SenderBuilder {
             transport: self.transport,
             device_id: self.device_id,
             manifest_href: self.manifest_href.unwrap_or_default(),
+            caps: None,
         }
     }
 }
@@ -90,6 +91,7 @@ pub struct Sender {
     pub transport: Transport,
     pub device_id: Uuid,
     pub manifest_href: String,
+    pub caps: Option<BTreeMap<String, serde_json::Value>>,
 }
 
 impl Sender {
@@ -151,8 +153,7 @@ impl Into<v1_3_x::Sender> for Sender {
     fn into(self) -> v1_3_x::Sender {
         v1_3_x::Sender {
             interface_bindings: vec![],
-            // TODO: implement caps
-            caps: None,
+            caps: self.caps,
             id: self.core.id.to_string(),
             version: self.core.version.to_string(),
             label: self.core.label.clone(),

--- a/model/src/resource/source.rs
+++ b/model/src/resource/source.rs
@@ -73,22 +73,7 @@ impl Source {
     #[must_use]
     pub fn to_json(&self, api: &APIVersion) -> SourceJson {
         match *api {
-            V1_0 => {
-                let tags = self.core.tags_json();
-                let parents = self.parents.iter().map(ToString::to_string).collect();
-
-                SourceJson::V1_0(v1_0_x::Source {
-                    id: self.core.id.to_string(),
-                    version: self.core.version.to_string(),
-                    label: self.core.label.clone(),
-                    description: self.core.description.clone(),
-                    format: self.format.to_string(),
-                    caps: BTreeMap::default(),
-                    tags,
-                    device_id: self.device_id.to_string(),
-                    parents,
-                })
-            }
+            V1_0 => SourceJson::V1_0((*self).clone().into()),
             V1_3 => SourceJson::V1_3((*self).clone().into()),
             _ => panic!("Unsupported API"),
         }
@@ -113,6 +98,25 @@ impl Registerable for Source {
 pub enum SourceJson {
     V1_0(v1_0_x::Source),
     V1_3(v1_3_x::Source),
+}
+
+impl Into<v1_0_x::Source> for Source {
+    fn into(self) -> v1_0_x::Source {
+        let tags = self.core.tags_json();
+        let parents = self.parents.iter().map(ToString::to_string).collect();
+
+        v1_0_x::Source {
+            id: self.core.id.to_string(),
+            version: self.core.version.to_string(),
+            label: self.core.label.clone(),
+            description: self.core.description.clone(),
+            format: self.format.to_string(),
+            caps: BTreeMap::default(),
+            tags,
+            device_id: self.device_id.to_string(),
+            parents,
+        }
+    }
 }
 
 impl Into<v1_3_x::Source> for Source {

--- a/model/src/resource/source.rs
+++ b/model/src/resource/source.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 
 use nmos_schema::is_04::{v1_0_x, v1_3_x};
 use serde::Serialize;
+use serde_json::json;
 use uuid::Uuid;
 
 use crate::{
@@ -10,6 +11,17 @@ use crate::{
 };
 
 use super::{ResourceCore, ResourceCoreBuilder};
+
+macro_rules! registration_request {
+    ($value:expr, $version:ident) => {
+        json!($version::RegistrationapiResourcePostRequest::Variant4(
+            $version::RegistrationapiResourcePostRequestHealthVariant4 {
+                data: Some($value),
+                type_: Some(String::from("source")),
+            }
+        ))
+    };
+}
 
 #[must_use]
 pub struct SourceBuilder {
@@ -79,6 +91,13 @@ impl Source {
             }
             V1_3 => SourceJson::V1_3((*self).clone().into()),
             _ => panic!("Unsupported API"),
+        }
+    }
+
+    pub fn registration_request(&self, api: &APIVersion) -> serde_json::Value {
+        match self.to_json(api) {
+            SourceJson::V1_0(json) => registration_request!(json, v1_0_x),
+            SourceJson::V1_3(json) => registration_request!(json, v1_3_x),
         }
     }
 }

--- a/model/src/resource/source.rs
+++ b/model/src/resource/source.rs
@@ -45,7 +45,7 @@ impl SourceBuilder {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Source {
     pub core: ResourceCore,
     pub format: Format,
@@ -62,16 +62,7 @@ impl Source {
     pub fn to_json(&self, api: &APIVersion) -> SourceJson {
         match *api {
             V1_0 => {
-                let tags = self
-                    .core
-                    .tags
-                    .iter()
-                    .fold(BTreeMap::new(), |mut map, (key, array)| {
-                        let value = serde_json::Value::from(array.clone());
-                        map.insert(key.clone(), value);
-                        map
-                    });
-
+                let tags = self.core.tags_json();
                 let parents = self.parents.iter().map(ToString::to_string).collect();
 
                 SourceJson::V1_0(v1_0_x::Source {
@@ -86,33 +77,7 @@ impl Source {
                     parents,
                 })
             }
-            V1_3 => {
-                let tags = self
-                    .core
-                    .tags
-                    .iter()
-                    .fold(BTreeMap::new(), |mut map, (key, array)| {
-                        let value = serde_json::Value::from(array.clone());
-                        map.insert(key.clone(), value);
-                        map
-                    });
-
-                let parents = self.parents.iter().map(ToString::to_string).collect();
-
-                SourceJson::V1_3(v1_3_x::SourceVersion::Variant0(v1_3_x::SourceGeneric {
-                    clock_name: None,
-                    grain_rate: None,
-                    id: self.core.id.to_string(),
-                    version: self.core.version.to_string(),
-                    label: self.core.label.clone(),
-                    description: self.core.description.clone(),
-                    format: self.format.to_string(),
-                    caps: BTreeMap::default(),
-                    tags,
-                    device_id: self.device_id.to_string(),
-                    parents,
-                }))
-            }
+            V1_3 => SourceJson::V1_3((*self).clone().into()),
             _ => panic!("Unsupported API"),
         }
     }
@@ -122,5 +87,50 @@ impl Source {
 #[serde(untagged)]
 pub enum SourceJson {
     V1_0(v1_0_x::Source),
-    V1_3(v1_3_x::SourceVersion),
+    V1_3(v1_3_x::Source),
+}
+
+impl Into<v1_3_x::Source> for Source {
+    fn into(self) -> v1_3_x::Source {
+        let id = self.core.id.to_string();
+        let label = self.core.label.clone();
+        let description = self.core.description.clone();
+        let tags = self.core.tags_json();
+        let parents = self.parents.iter().map(ToString::to_string).collect();
+        let device_id = self.device_id.to_string();
+        let clock_name: Option<std::string::String> = None;
+        let version = self.core.version.to_string();
+        let format = self.format.to_string();
+        let caps = BTreeMap::default();
+
+        match self.format {
+            Format::Data | Format::Video => v1_3_x::Source::Variant0(v1_3_x::SourceGeneric {
+                clock_name,
+                id,
+                version,
+                label,
+                description,
+                format,
+                tags,
+                caps,
+                parents,
+                device_id,
+                grain_rate: None,
+            }),
+            Format::Audio => v1_3_x::Source::Variant1(v1_3_x::SourceAudio {
+                clock_name,
+                id,
+                version,
+                label,
+                description,
+                format,
+                tags,
+                caps,
+                parents,
+                device_id,
+                channels: vec![],
+                grain_rate: None,
+            }),
+        }
+    }
 }

--- a/model/src/resource/source.rs
+++ b/model/src/resource/source.rs
@@ -73,8 +73,8 @@ impl Source {
     #[must_use]
     pub fn to_json(&self, api: &APIVersion) -> SourceJson {
         match *api {
-            V1_0 => SourceJson::V1_0((*self).clone().into()),
-            V1_3 => SourceJson::V1_3((*self).clone().into()),
+            V1_0 => SourceJson::V1_0(self.clone().into()),
+            V1_3 => SourceJson::V1_3(self.clone().into()),
             _ => panic!("Unsupported API"),
         }
     }

--- a/model/src/resource/source.rs
+++ b/model/src/resource/source.rs
@@ -32,7 +32,7 @@ pub struct SourceBuilder {
 }
 
 impl SourceBuilder {
-    pub fn new<S: Into<String>>(label: S, device: &Device, format: Format) -> Self {
+    pub fn new(label: impl Into<String>, device: &Device, format: Format) -> Self {
         SourceBuilder {
             core: ResourceCoreBuilder::new(label),
             format,
@@ -66,7 +66,7 @@ pub struct Source {
 }
 
 impl Source {
-    pub fn builder<S: Into<String>>(label: S, device: &Device, format: Format) -> SourceBuilder {
+    pub fn builder(label: impl Into<String>, device: &Device, format: Format) -> SourceBuilder {
         SourceBuilder::new(label, device, format)
     }
 

--- a/model/src/resource/source.rs
+++ b/model/src/resource/source.rs
@@ -10,7 +10,7 @@ use crate::{
     version::{is_04::V1_0, is_04::V1_3, APIVersion},
 };
 
-use super::{ResourceCore, ResourceCoreBuilder};
+use super::{Registerable, ResourceCore, ResourceCoreBuilder};
 
 macro_rules! registration_request {
     ($value:expr, $version:ident) => {
@@ -93,8 +93,14 @@ impl Source {
             _ => panic!("Unsupported API"),
         }
     }
+}
 
-    pub fn registration_request(&self, api: &APIVersion) -> serde_json::Value {
+impl Registerable for Source {
+    fn registry_path(&self) -> String {
+        format!("sources/{}", self.core.id)
+    }
+
+    fn registration_request(&self, api: &APIVersion) -> serde_json::Value {
         match self.to_json(api) {
             SourceJson::V1_0(json) => registration_request!(json, v1_0_x),
             SourceJson::V1_3(json) => registration_request!(json, v1_3_x),

--- a/model/src/resource/source.rs
+++ b/model/src/resource/source.rs
@@ -128,7 +128,16 @@ impl Into<v1_3_x::Source> for Source {
                 caps,
                 parents,
                 device_id,
-                channels: vec![],
+                channels: vec![
+                    v1_3_x::SourceAudioItemChannels {
+                        label: "L".into(),
+                        symbol: None,
+                    },
+                    v1_3_x::SourceAudioItemChannels {
+                        label: "R".into(),
+                        symbol: None,
+                    },
+                ],
                 grain_rate: None,
             }),
         }

--- a/model/src/tai.rs
+++ b/model/src/tai.rs
@@ -3,6 +3,7 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
+#[derive(Clone)]
 pub struct TaiTime {
     secs: u64,
     nanos: u32,

--- a/model/src/version.rs
+++ b/model/src/version.rs
@@ -44,4 +44,5 @@ pub mod is_04 {
     use super::APIVersion;
 
     pub const V1_0: APIVersion = APIVersion { major: 1, minor: 0 };
+    pub const V1_3: APIVersion = APIVersion { major: 1, minor: 3 };
 }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -9,7 +9,6 @@ license = "Apache-2.0"
 rust-version = "1.56"
 
 [dependencies]
-async-trait = "0.1"
 axum = { version = "0.5", default-features = false, features = ["http1", "json", "original-uri", "tower-log"] }
 futures = "0.3"
 nmos-model = { path = "../model" }

--- a/node/examples/gstreamer.rs
+++ b/node/examples/gstreamer.rs
@@ -58,7 +58,7 @@ fn create_node() -> Node {
         resource::Source::builder("GStreamer test source", &device, resource::Format::Video)
             .description("SMPTE video test stream")
             .build();
-    let flow = resource::Flow::builder("GStreamer VP8 test flow", &source).build();
+    let flow = resource::Flow::builder("GStreamer VP8 test flow", &source, &device).build();
 
     // Create sender
     let sender = resource::Sender::builder(

--- a/node/src/api/mod.rs
+++ b/node/src/api/mod.rs
@@ -16,7 +16,6 @@ use error::ServiceError;
 use futures::Future;
 use nmos_model::Model;
 use serde_json::json;
-use tokio::sync::Mutex;
 use tower::Service;
 
 use self::node::{
@@ -32,7 +31,7 @@ pub struct NodeApi {
 }
 
 impl NodeApi {
-    pub fn new(model: Arc<Mutex<Model>>) -> Self {
+    pub fn new(model: Arc<Model>) -> Self {
         let router = Router::new()
             .route(
                 "/",

--- a/node/src/api/mod.rs
+++ b/node/src/api/mod.rs
@@ -39,7 +39,10 @@ impl NodeApi {
                 get(|| async { Json(json!(["x-manifest/", "x-nmos/"])) }),
             )
             .route("/x-nmos/", get(|| async { Json(json!(["node/"])) }))
-            .route("/x-nmos/node/", get(|| async { Json(json!(["v1.0/"])) }))
+            .route(
+                "/x-nmos/node/",
+                get(|| async { Json(json!(["v1.0/", "v1.3/"])) }),
+            )
             .route(
                 "/x-nmos/node/v1.0/",
                 get(|| async {

--- a/node/src/api/mod.rs
+++ b/node/src/api/mod.rs
@@ -44,7 +44,7 @@ impl NodeApi {
                 get(|| async { Json(json!(["v1.0/", "v1.3/"])) }),
             )
             .route(
-                "/x-nmos/node/v1.0/",
+                "/x-nmos/node/:api/",
                 get(|| async {
                     Json(json!([
                         "devices/",

--- a/node/src/api/mod.rs
+++ b/node/src/api/mod.rs
@@ -16,6 +16,7 @@ use error::ServiceError;
 use futures::Future;
 use nmos_model::Model;
 use serde_json::json;
+use tokio::sync::Mutex;
 use tower::Service;
 
 use self::node::{
@@ -31,7 +32,7 @@ pub struct NodeApi {
 }
 
 impl NodeApi {
-    pub fn new(model: Arc<Model>) -> Self {
+    pub fn new(model: Arc<Mutex<Model>>) -> Self {
         let router = Router::new()
             .route(
                 "/",

--- a/node/src/api/node.rs
+++ b/node/src/api/node.rs
@@ -8,6 +8,7 @@ use nmos_model::resource::{DeviceJson, FlowJson, NodeJson, ReceiverJson, SenderJ
 use nmos_model::version::is_04::V1_0;
 use nmos_model::version::APIVersion;
 use nmos_model::Model;
+use tokio::sync::Mutex;
 use uuid::Uuid;
 
 use super::ServiceError;
@@ -37,8 +38,10 @@ fn parse_api_version(api: &str) -> Result<APIVersion, ServiceError> {
 
 pub async fn get_self(
     Path(api): Path<String>,
-    Extension(model): Extension<Arc<Model>>,
+    Extension(model): Extension<Arc<Mutex<Model>>>,
 ) -> Result<Json<NodeJson>, ServiceError> {
+    let model = model.lock().await;
+
     let api = parse_api_version(&api)?;
 
     let nodes = model.nodes().await;
@@ -55,8 +58,10 @@ pub async fn get_self(
 
 pub async fn get_devices(
     Path(api): Path<String>,
-    Extension(model): Extension<Arc<Model>>,
+    Extension(model): Extension<Arc<Mutex<Model>>>,
 ) -> Result<Json<Vec<DeviceJson>>, ServiceError> {
+    let model = model.lock().await;
+
     let api = parse_api_version(&api)?;
 
     let devices = model.devices().await;
@@ -71,8 +76,10 @@ pub async fn get_devices(
 
 pub async fn get_device(
     Path((api, id)): Path<(String, Uuid)>,
-    Extension(model): Extension<Arc<Model>>,
+    Extension(model): Extension<Arc<Mutex<Model>>>,
 ) -> Result<Json<DeviceJson>, ServiceError> {
+    let model = model.lock().await;
+
     let api = parse_api_version(&api)?;
 
     let devices = model.devices().await;
@@ -93,8 +100,10 @@ pub async fn get_device(
 
 pub async fn get_receivers(
     Path(api): Path<String>,
-    Extension(model): Extension<Arc<Model>>,
+    Extension(model): Extension<Arc<Mutex<Model>>>,
 ) -> Result<Json<Vec<ReceiverJson>>, ServiceError> {
+    let model = model.lock().await;
+
     let api = parse_api_version(&api)?;
 
     let receivers = model.receivers().await;
@@ -109,8 +118,10 @@ pub async fn get_receivers(
 
 pub async fn get_receiver(
     Path((api, id)): Path<(String, Uuid)>,
-    Extension(model): Extension<Arc<Model>>,
+    Extension(model): Extension<Arc<Mutex<Model>>>,
 ) -> Result<Json<ReceiverJson>, ServiceError> {
+    let model = model.lock().await;
+
     let api = parse_api_version(&api)?;
 
     let receivers = model.receivers().await;
@@ -130,8 +141,10 @@ pub async fn get_receiver(
 
 pub async fn get_senders(
     Path(api): Path<String>,
-    Extension(model): Extension<Arc<Model>>,
+    Extension(model): Extension<Arc<Mutex<Model>>>,
 ) -> Result<Json<Vec<SenderJson>>, ServiceError> {
+    let model = model.lock().await;
+
     let api = parse_api_version(&api)?;
 
     let senders = model.senders().await;
@@ -146,8 +159,10 @@ pub async fn get_senders(
 
 pub async fn get_sender(
     Path((api, id)): Path<(String, Uuid)>,
-    Extension(model): Extension<Arc<Model>>,
+    Extension(model): Extension<Arc<Mutex<Model>>>,
 ) -> Result<Json<SenderJson>, ServiceError> {
+    let model = model.lock().await;
+
     let api = parse_api_version(&api)?;
 
     let senders = model.senders().await;
@@ -167,8 +182,10 @@ pub async fn get_sender(
 
 pub async fn get_sources(
     Path(api): Path<String>,
-    Extension(model): Extension<Arc<Model>>,
+    Extension(model): Extension<Arc<Mutex<Model>>>,
 ) -> Result<Json<Vec<SourceJson>>, ServiceError> {
+    let model = model.lock().await;
+
     let api = parse_api_version(&api)?;
 
     let sources = model.sources().await;
@@ -183,8 +200,10 @@ pub async fn get_sources(
 
 pub async fn get_source(
     Path((api, id)): Path<(String, Uuid)>,
-    Extension(model): Extension<Arc<Model>>,
+    Extension(model): Extension<Arc<Mutex<Model>>>,
 ) -> Result<Json<SourceJson>, ServiceError> {
+    let model = model.lock().await;
+
     let api = parse_api_version(&api)?;
 
     let sources = model.sources().await;
@@ -204,8 +223,10 @@ pub async fn get_source(
 
 pub async fn get_flows(
     Path(api): Path<String>,
-    Extension(model): Extension<Arc<Model>>,
+    Extension(model): Extension<Arc<Mutex<Model>>>,
 ) -> Result<Json<Vec<FlowJson>>, ServiceError> {
+    let model = model.lock().await;
+
     let api = parse_api_version(&api)?;
 
     let flows = model.flows().await;
@@ -217,8 +238,10 @@ pub async fn get_flows(
 
 pub async fn get_flow(
     Path((api, id)): Path<(String, Uuid)>,
-    Extension(model): Extension<Arc<Model>>,
+    Extension(model): Extension<Arc<Mutex<Model>>>,
 ) -> Result<Json<FlowJson>, ServiceError> {
+    let model = model.lock().await;
+
     let api = parse_api_version(&api)?;
 
     let flows = model.flows().await;

--- a/node/src/api/node.rs
+++ b/node/src/api/node.rs
@@ -8,7 +8,6 @@ use nmos_model::resource::{DeviceJson, FlowJson, NodeJson, ReceiverJson, SenderJ
 use nmos_model::version::is_04::{V1_0, V1_3};
 use nmos_model::version::APIVersion;
 use nmos_model::Model;
-use tokio::sync::Mutex;
 use uuid::Uuid;
 
 use super::ServiceError;
@@ -38,10 +37,8 @@ fn parse_api_version(api: &str) -> Result<APIVersion, ServiceError> {
 
 pub async fn get_self(
     Path(api): Path<String>,
-    Extension(model): Extension<Arc<Mutex<Model>>>,
+    Extension(model): Extension<Arc<Model>>,
 ) -> Result<Json<NodeJson>, ServiceError> {
-    let model = model.lock().await;
-
     let api = parse_api_version(&api)?;
 
     let nodes = model.nodes().await;
@@ -58,10 +55,8 @@ pub async fn get_self(
 
 pub async fn get_devices(
     Path(api): Path<String>,
-    Extension(model): Extension<Arc<Mutex<Model>>>,
+    Extension(model): Extension<Arc<Model>>,
 ) -> Result<Json<Vec<DeviceJson>>, ServiceError> {
-    let model = model.lock().await;
-
     let api = parse_api_version(&api)?;
 
     let devices = model.devices().await;
@@ -76,10 +71,8 @@ pub async fn get_devices(
 
 pub async fn get_device(
     Path((api, id)): Path<(String, Uuid)>,
-    Extension(model): Extension<Arc<Mutex<Model>>>,
+    Extension(model): Extension<Arc<Model>>,
 ) -> Result<Json<DeviceJson>, ServiceError> {
-    let model = model.lock().await;
-
     let api = parse_api_version(&api)?;
 
     let devices = model.devices().await;
@@ -100,10 +93,8 @@ pub async fn get_device(
 
 pub async fn get_receivers(
     Path(api): Path<String>,
-    Extension(model): Extension<Arc<Mutex<Model>>>,
+    Extension(model): Extension<Arc<Model>>,
 ) -> Result<Json<Vec<ReceiverJson>>, ServiceError> {
-    let model = model.lock().await;
-
     let api = parse_api_version(&api)?;
 
     let receivers = model.receivers().await;
@@ -118,10 +109,8 @@ pub async fn get_receivers(
 
 pub async fn get_receiver(
     Path((api, id)): Path<(String, Uuid)>,
-    Extension(model): Extension<Arc<Mutex<Model>>>,
+    Extension(model): Extension<Arc<Model>>,
 ) -> Result<Json<ReceiverJson>, ServiceError> {
-    let model = model.lock().await;
-
     let api = parse_api_version(&api)?;
 
     let receivers = model.receivers().await;
@@ -141,10 +130,8 @@ pub async fn get_receiver(
 
 pub async fn get_senders(
     Path(api): Path<String>,
-    Extension(model): Extension<Arc<Mutex<Model>>>,
+    Extension(model): Extension<Arc<Model>>,
 ) -> Result<Json<Vec<SenderJson>>, ServiceError> {
-    let model = model.lock().await;
-
     let api = parse_api_version(&api)?;
 
     let senders = model.senders().await;
@@ -159,10 +146,8 @@ pub async fn get_senders(
 
 pub async fn get_sender(
     Path((api, id)): Path<(String, Uuid)>,
-    Extension(model): Extension<Arc<Mutex<Model>>>,
+    Extension(model): Extension<Arc<Model>>,
 ) -> Result<Json<SenderJson>, ServiceError> {
-    let model = model.lock().await;
-
     let api = parse_api_version(&api)?;
 
     let senders = model.senders().await;
@@ -182,10 +167,8 @@ pub async fn get_sender(
 
 pub async fn get_sources(
     Path(api): Path<String>,
-    Extension(model): Extension<Arc<Mutex<Model>>>,
+    Extension(model): Extension<Arc<Model>>,
 ) -> Result<Json<Vec<SourceJson>>, ServiceError> {
-    let model = model.lock().await;
-
     let api = parse_api_version(&api)?;
 
     let sources = model.sources().await;
@@ -200,10 +183,8 @@ pub async fn get_sources(
 
 pub async fn get_source(
     Path((api, id)): Path<(String, Uuid)>,
-    Extension(model): Extension<Arc<Mutex<Model>>>,
+    Extension(model): Extension<Arc<Model>>,
 ) -> Result<Json<SourceJson>, ServiceError> {
-    let model = model.lock().await;
-
     let api = parse_api_version(&api)?;
 
     let sources = model.sources().await;
@@ -223,10 +204,8 @@ pub async fn get_source(
 
 pub async fn get_flows(
     Path(api): Path<String>,
-    Extension(model): Extension<Arc<Mutex<Model>>>,
+    Extension(model): Extension<Arc<Model>>,
 ) -> Result<Json<Vec<FlowJson>>, ServiceError> {
-    let model = model.lock().await;
-
     let api = parse_api_version(&api)?;
 
     let flows = model.flows().await;
@@ -238,10 +217,8 @@ pub async fn get_flows(
 
 pub async fn get_flow(
     Path((api, id)): Path<(String, Uuid)>,
-    Extension(model): Extension<Arc<Mutex<Model>>>,
+    Extension(model): Extension<Arc<Model>>,
 ) -> Result<Json<FlowJson>, ServiceError> {
-    let model = model.lock().await;
-
     let api = parse_api_version(&api)?;
 
     let flows = model.flows().await;

--- a/node/src/api/node.rs
+++ b/node/src/api/node.rs
@@ -5,7 +5,7 @@ use axum::extract::Path;
 use axum::http::StatusCode;
 use axum::{Extension, Json};
 use nmos_model::resource::{DeviceJson, FlowJson, NodeJson, ReceiverJson, SenderJson, SourceJson};
-use nmos_model::version::is_04::V1_0;
+use nmos_model::version::is_04::{V1_0, V1_3};
 use nmos_model::version::APIVersion;
 use nmos_model::Model;
 use tokio::sync::Mutex;
@@ -13,7 +13,7 @@ use uuid::Uuid;
 
 use super::ServiceError;
 
-const SUPPORTED_API_VERSIONS: &[APIVersion] = &[V1_0];
+const SUPPORTED_API_VERSIONS: &[APIVersion] = &[V1_0, V1_3];
 
 fn parse_api_version(api: &str) -> Result<APIVersion, ServiceError> {
     let api = match APIVersion::from_str(api) {

--- a/node/src/api/registration.rs
+++ b/node/src/api/registration.rs
@@ -30,11 +30,10 @@ impl RegistrationApi {
             .error_for_status()?;
 
         if res.status() == StatusCode::OK {
-            let mut delete_url = url.clone();
-            delete_url
-                .path_segments_mut()
-                .unwrap()
-                .push(resource.registry_path().as_str());
+            let delete_url = url
+                .clone()
+                .join(format!("resource{}", resource.registry_path()).as_str())
+                .unwrap();
 
             warn!("Resource already present in API deleting: {}", delete_url);
 
@@ -60,11 +59,10 @@ impl RegistrationApi {
 
     pub async fn register_resources(
         client: &reqwest::Client,
-        model: Arc<Mutex<Model>>,
+        model: Arc<Model>,
         registry: Arc<Mutex<Option<NmosMdnsRegistry>>>,
         api_version: &APIVersion,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let model = model.lock().await;
         let registry = registry.lock().await.clone().unwrap();
 
         let base = &registry

--- a/node/src/api/registration.rs
+++ b/node/src/api/registration.rs
@@ -52,7 +52,8 @@ impl RegistrationApi {
                 Variant0
             ))
             .send()
-            .await?;
+            .await?
+            .error_for_status()?;
 
         Ok(())
     }
@@ -73,7 +74,8 @@ impl RegistrationApi {
                 Variant1
             ))
             .send()
-            .await?;
+            .await?
+            .error_for_status()?;
 
         Ok(())
     }
@@ -94,7 +96,8 @@ impl RegistrationApi {
                 Variant4
             ))
             .send()
-            .await?;
+            .await?
+            .error_for_status()?;
 
         Ok(())
     }
@@ -115,7 +118,8 @@ impl RegistrationApi {
                 Variant5
             ))
             .send()
-            .await?;
+            .await?
+            .error_for_status()?;
 
         Ok(())
     }
@@ -136,7 +140,8 @@ impl RegistrationApi {
                 Variant2
             ))
             .send()
-            .await?;
+            .await?
+            .error_for_status()?;
 
         Ok(())
     }
@@ -157,7 +162,8 @@ impl RegistrationApi {
                 Variant3
             ))
             .send()
-            .await?;
+            .await?
+            .error_for_status()?;
 
         Ok(())
     }

--- a/node/src/api/registration.rs
+++ b/node/src/api/registration.rs
@@ -82,7 +82,7 @@ impl RegistrationApi {
 
         let base = &registry
             .url
-            .join(format!("{}/", api_version.to_string()).as_str())
+            .join(format!("{}/", api_version).as_str())
             .unwrap();
 
         let resource_url = &base.join("resource").unwrap();
@@ -91,27 +91,27 @@ impl RegistrationApi {
 
         // Register resources in order
         debug!("Registering nodes...");
-        for (_, node) in model.nodes().await.iter() {
+        for node in model.nodes().await.values() {
             Self::register_resource(client, resource_url, node, api_version).await?;
         }
         debug!("Registering devices...");
-        for (_, device) in model.devices().await.iter() {
+        for device in model.devices().await.values() {
             Self::register_resource(client, resource_url, device, api_version).await?;
         }
         debug!("Registering sources...");
-        for (_, source) in model.sources().await.iter() {
+        for source in model.sources().await.values() {
             Self::register_resource(client, resource_url, source, api_version).await?;
         }
         debug!("Registering flows...");
-        for (_, flow) in model.flows().await.iter() {
+        for flow in model.flows().await.values() {
             Self::register_resource(client, resource_url, flow, api_version).await?;
         }
         debug!("Registering senders...");
-        for (_, sender) in model.senders().await.iter() {
+        for sender in model.senders().await.values() {
             Self::register_resource(client, resource_url, sender, api_version).await?;
         }
         debug!("Registering receivers...");
-        for (_, receiver) in model.receivers().await.iter() {
+        for receiver in model.receivers().await.values() {
             Self::register_resource(client, resource_url, receiver, api_version).await?;
         }
 

--- a/node/src/api/registration.rs
+++ b/node/src/api/registration.rs
@@ -4,7 +4,7 @@ use nmos_model::{resource, version::APIVersion, Model};
 use nmos_schema::is_04::{v1_0_x, v1_3_x};
 use serde_json::json;
 use tokio::sync::Mutex;
-use tracing::info;
+use tracing::{debug, info};
 
 use crate::mdns::NmosMdnsRegistry;
 
@@ -181,8 +181,6 @@ impl RegistrationApi {
             .join(format!("{}/", api_version.to_string()).as_str())
             .unwrap();
 
-        info!("All received registries: {:?}", registry);
-
         info!("Attempting to register with {}", base);
 
         // Resource endpoint
@@ -193,25 +191,25 @@ impl RegistrationApi {
         let node = nodes.iter().next().unwrap().1;
 
         // Register resources in order
-        info!("Registering node...");
+        debug!("Registering node...");
         Self::register_node(client, resource_url, node, api_version).await?;
-        info!("Registering devices...");
+        debug!("Registering devices...");
         for (_, device) in model.devices().await.iter() {
             Self::register_device(client, resource_url, device, api_version).await?;
         }
-        info!("Registering sources...");
+        debug!("Registering sources...");
         for (_, source) in model.sources().await.iter() {
             Self::register_source(client, resource_url, source, api_version).await?;
         }
-        info!("Registering flows...");
+        debug!("Registering flows...");
         for (_, flow) in model.flows().await.iter() {
             Self::register_flow(client, resource_url, flow, api_version).await?;
         }
-        info!("Registering senders...");
+        debug!("Registering senders...");
         for (_, sender) in model.senders().await.iter() {
             Self::register_sender(client, resource_url, sender, api_version).await?;
         }
-        info!("Registering receivers...");
+        debug!("Registering receivers...");
         for (_, receiver) in model.receivers().await.iter() {
             Self::register_receiver(client, resource_url, receiver, api_version).await?;
         }

--- a/node/src/api/registration.rs
+++ b/node/src/api/registration.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use nmos_model::{resource, Model};
+use tokio::sync::Mutex;
 use tracing::info;
 
 use crate::mdns::NmosMdnsRegistry;
@@ -146,9 +147,11 @@ impl RegistrationApi {
 
     pub async fn register_resources(
         client: &reqwest::Client,
-        model: Arc<Model>,
+        model: Arc<Mutex<Model>>,
         registry: &NmosMdnsRegistry,
     ) -> Result<(), Box<dyn std::error::Error>> {
+        let model = model.lock().await;
+
         let base = &registry.url.join("v1.0/").unwrap();
 
         info!("Attempting to register with {}", base);

--- a/node/src/api/registration.rs
+++ b/node/src/api/registration.rs
@@ -181,6 +181,8 @@ impl RegistrationApi {
             .join(format!("{}/", api_version.to_string()).as_str())
             .unwrap();
 
+        info!("All received registries: {:?}", registry);
+
         info!("Attempting to register with {}", base);
 
         // Resource endpoint
@@ -191,19 +193,25 @@ impl RegistrationApi {
         let node = nodes.iter().next().unwrap().1;
 
         // Register resources in order
+        info!("Registering node...");
         Self::register_node(client, resource_url, node, api_version).await?;
+        info!("Registering devices...");
         for (_, device) in model.devices().await.iter() {
             Self::register_device(client, resource_url, device, api_version).await?;
         }
+        info!("Registering sources...");
         for (_, source) in model.sources().await.iter() {
             Self::register_source(client, resource_url, source, api_version).await?;
         }
+        info!("Registering flows...");
         for (_, flow) in model.flows().await.iter() {
             Self::register_flow(client, resource_url, flow, api_version).await?;
         }
+        info!("Registering senders...");
         for (_, sender) in model.senders().await.iter() {
             Self::register_sender(client, resource_url, sender, api_version).await?;
         }
+        info!("Registering receivers...");
         for (_, receiver) in model.receivers().await.iter() {
             Self::register_receiver(client, resource_url, receiver, api_version).await?;
         }

--- a/node/src/api/registration.rs
+++ b/node/src/api/registration.rs
@@ -61,10 +61,11 @@ impl RegistrationApi {
     pub async fn register_resources(
         client: &reqwest::Client,
         model: Arc<Mutex<Model>>,
-        registry: &NmosMdnsRegistry,
+        registry: Arc<Mutex<Option<NmosMdnsRegistry>>>,
         api_version: &APIVersion,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let model = model.lock().await;
+        let registry = registry.lock().await.clone().unwrap();
 
         let base = &registry
             .url

--- a/node/src/api/registration.rs
+++ b/node/src/api/registration.rs
@@ -1,39 +1,12 @@
 use std::sync::Arc;
 
 use nmos_model::{resource, version::APIVersion, Model};
-use nmos_schema::is_04::{v1_0_x, v1_3_x};
-use serde_json::json;
 use tokio::sync::Mutex;
 use tracing::{debug, info};
 
 use crate::mdns::NmosMdnsRegistry;
 
 pub struct RegistrationApi;
-
-macro_rules! api_post_request {
-    ($resource:expr, $r_type:expr,$json_enum:ident, $request:ident, $variant:ident) => {
-        match $resource {
-            resource::$json_enum::V1_0(json) => {
-                let request = v1_0_x::$request {
-                    data: Some(json),
-                    type_: Some(String::from($r_type.to_string())),
-                };
-                json!(v1_0_x::RegistrationapiResourcePostRequest::$variant(
-                    request
-                ))
-            }
-            resource::$json_enum::V1_3(json) => {
-                let request = v1_3_x::$request {
-                    data: Some(json),
-                    type_: Some(String::from($r_type.to_string())),
-                };
-                json!(v1_3_x::RegistrationapiResourcePostRequest::$variant(
-                    request
-                ))
-            }
-        }
-    };
-}
 
 impl RegistrationApi {
     async fn register_node(
@@ -44,13 +17,7 @@ impl RegistrationApi {
     ) -> Result<(), Box<dyn std::error::Error>> {
         client
             .post(url.clone())
-            .json(&api_post_request!(
-                node.to_json(&api_version),
-                "node",
-                NodeJson,
-                RegistrationapiResourcePostRequestHealthVariant0,
-                Variant0
-            ))
+            .json(&node.registration_request(api_version))
             .send()
             .await?
             .error_for_status()?;
@@ -66,13 +33,7 @@ impl RegistrationApi {
     ) -> Result<(), Box<dyn std::error::Error>> {
         client
             .post(url.clone())
-            .json(&api_post_request!(
-                device.to_json(&api_version),
-                "device",
-                DeviceJson,
-                RegistrationapiResourcePostRequestHealthVariant1,
-                Variant1
-            ))
+            .json(&device.registration_request(api_version))
             .send()
             .await?
             .error_for_status()?;
@@ -88,13 +49,7 @@ impl RegistrationApi {
     ) -> Result<(), Box<dyn std::error::Error>> {
         client
             .post(url.clone())
-            .json(&api_post_request!(
-                source.to_json(&api_version),
-                "source",
-                SourceJson,
-                RegistrationapiResourcePostRequestHealthVariant4,
-                Variant4
-            ))
+            .json(&source.registration_request(api_version))
             .send()
             .await?
             .error_for_status()?;
@@ -110,13 +65,7 @@ impl RegistrationApi {
     ) -> Result<(), Box<dyn std::error::Error>> {
         client
             .post(url.clone())
-            .json(&api_post_request!(
-                flow.to_json(&api_version),
-                "flow",
-                FlowJson,
-                RegistrationapiResourcePostRequestHealthVariant5,
-                Variant5
-            ))
+            .json(&flow.registration_request(api_version))
             .send()
             .await?
             .error_for_status()?;
@@ -132,13 +81,7 @@ impl RegistrationApi {
     ) -> Result<(), Box<dyn std::error::Error>> {
         client
             .post(url.clone())
-            .json(&api_post_request!(
-                sender.to_json(&api_version),
-                "sender",
-                SenderJson,
-                RegistrationapiResourcePostRequestHealthVariant2,
-                Variant2
-            ))
+            .json(&sender.registration_request(api_version))
             .send()
             .await?
             .error_for_status()?;
@@ -154,13 +97,7 @@ impl RegistrationApi {
     ) -> Result<(), Box<dyn std::error::Error>> {
         client
             .post(url.clone())
-            .json(&api_post_request!(
-                receiver.to_json(&api_version),
-                "receiver",
-                ReceiverJson,
-                RegistrationapiResourcePostRequestHealthVariant3,
-                Variant3
-            ))
+            .json(&receiver.registration_request(api_version))
             .send()
             .await?
             .error_for_status()?;

--- a/node/src/event_handler.rs
+++ b/node/src/event_handler.rs
@@ -1,4 +1,0 @@
-use async_trait::async_trait;
-
-#[async_trait]
-pub trait EventHandler: Send + Sync {}

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -226,10 +226,7 @@ impl Node {
                     let mut registry = self.current_registry.lock().await;
 
                     // Try and get highest priority registry
-                    *registry = {
-                        let mut registries = registries.lock().await;
-                        registries.pop()
-                    };
+                    *registry = registries.lock().await.pop();
 
                     // Don't register and heartbeat if no registry is available
                     if registry.is_none() {
@@ -261,9 +258,7 @@ impl Node {
 
                     registry
                         .url
-                        .join(&format!("{}/", self.api_version)) // Ensure it ends with a '/'
-                        .unwrap()
-                        .join(&format!("health/nodes/{}", node_id))
+                        .join(&format!("{}/health/nodes/{}", self.api_version, node_id))
                         .unwrap()
                 };
 
@@ -316,12 +311,12 @@ impl Node {
                 if let Some(reg) = self.current_registry.lock().await.clone() {
                     let base = &reg
                         .url
-                        .join(format!("{}/", self.api_version.to_string()).as_str())
+                        .join(format!("{}/", self.api_version).as_str())
                         .unwrap();
 
                     let url = &base.join("resource").unwrap();
 
-                    let res: Result<reqwest::Response, Box<dyn std::error::Error>> = match event {
+                    let res = match event {
                         ResourceUpdate::Update(resource) => {
                             RegistrationApi::post_resource(
                                 &client,

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -204,7 +204,10 @@ impl Node {
                     let nodes = model.nodes().await;
                     let node_id = *nodes.iter().next().unwrap().0;
 
-                    let base = &registry.url.join("v1.0/").unwrap();
+                    let base = &registry
+                        .url
+                        .join(self.api_version.to_string().as_str())
+                        .unwrap();
                     base.join(&format!("health/nodes/{}", node_id)).unwrap()
                 };
 

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -150,7 +150,11 @@ impl Node {
                             info!(
                                 "Discovered registry url: {} version: {:?} priority: {}",
                                 registry.url,
-                                registry.api_ver.iter().map(APIVersion::to_string),
+                                registry
+                                    .api_ver
+                                    .iter()
+                                    .map(APIVersion::to_string)
+                                    .collect::<Vec<_>>(),
                                 registry.pri
                             );
                             registries.push(registry);

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -222,15 +222,15 @@ impl Node {
                     let model = self.model.lock().await;
                     let nodes = model.nodes().await;
                     let node_id = *nodes.iter().next().unwrap().0;
-                    let base = &registry
+
+                    let mut base = registry
                         .url
-                        .join(self.api_version.to_string().as_str())
+                        .join(&format!("{}/", self.api_version)) // Ensure it ends with a '/'
                         .unwrap();
 
-                    base.join(&format!("health/nodes/{}", node_id)).unwrap()
+                    base = base.join(&format!("health/nodes/{}", node_id)).unwrap();
+                    base
                 };
-
-                tokio::time::sleep(Duration::from_secs(1)).await;
 
                 let mut attempts = 0;
                 // Send heartbeat every 5 seconds

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -175,7 +175,13 @@ impl Node {
                 let registry = {
                     let mut registries = self.registries.lock().await;
                     match registries.pop() {
-                        Some(r) => r,
+                        Some(r) => {
+                            if r.api_ver.contains(&self.api_version) {
+                                r
+                            } else {
+                                continue;
+                            }
+                        }
                         None => continue,
                     }
                 };

--- a/node/src/mdns.rs
+++ b/node/src/mdns.rs
@@ -10,7 +10,7 @@ use std::{
 use nmos_model::version::APIVersion;
 use reqwest::Url;
 use tokio::sync::mpsc::{self, UnboundedSender};
-use tracing::{error, info};
+use tracing::{debug, error, info};
 use zeroconf::{
     browser::TMdnsBrowser, event_loop::TEventLoop, service::TMdnsService, txt_record::TTxtRecord,
     EventLoop, MdnsBrowser, MdnsService, ServiceDiscovery, ServiceRegistration, ServiceType,
@@ -140,7 +140,7 @@ impl MdnsContext {
         context: &Option<Arc<dyn Any>>,
     ) {
         match &result {
-            Ok(d) => info!("Discovered service: {:?}", d),
+            Ok(d) => debug!("Discovered service: {:?}", d),
             Err(e) => error!("Service discovery error: {}", e),
         };
 

--- a/node/src/mdns.rs
+++ b/node/src/mdns.rs
@@ -19,7 +19,7 @@ use zeroconf::{
 
 pub struct NmosMdnsConfig {}
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct NmosMdnsRegistry {
     pub api_proto: String,
     pub api_ver: Vec<APIVersion>,

--- a/node/src/mdns.rs
+++ b/node/src/mdns.rs
@@ -29,7 +29,7 @@ pub struct NmosMdnsRegistry {
 }
 
 impl NmosMdnsRegistry {
-    pub fn parse(discovery: &ServiceDiscovery) -> Option<Self> {
+    pub fn parse(discovery: &ServiceDiscovery, api_version: &APIVersion) -> Option<Self> {
         debug!("{:?}", discovery);
 
         // TXT record required
@@ -72,6 +72,10 @@ impl NmosMdnsRegistry {
             // Parse api_ver
             let api_ver: Vec<APIVersion> =
                 api_ver.split(',').flat_map(APIVersion::from_str).collect();
+
+            if !api_ver.contains(api_version) {
+                return None;
+            }
 
             // Parse api_auth
             let api_auth = match api_auth.parse::<bool>() {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+jsonschema==3.2.0

--- a/schema/build.rs
+++ b/schema/build.rs
@@ -141,7 +141,7 @@ fn create_root_schema<P: AsRef<Path>>(path: P) -> Value {
 fn main() {
     // Fetch schemas from AMWA repository via submodules
     Command::new("git")
-        .args(&["submodule", "update", "--init"])
+        .args(["submodule", "update", "--init"])
         .status()
         .expect("Failed to update submodules");
 

--- a/schema/schema_checker
+++ b/schema/schema_checker
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import jsonschema
+from jsonschema import Draft7Validator, RefResolver
+
+
+def load_schema(file_path):
+    """Load a JSON schema file."""
+    with open(file_path) as f:
+        return json.load(f)
+
+
+def load_all_schemas(schema_path):
+    """Load the main schema and all other schemas in the same directory."""
+    schema_dir = os.path.dirname(os.path.abspath(schema_path))
+    schemas = {}
+
+    # Load the main schema
+    schemas['main'] = load_schema(schema_path)
+
+    # Load all other JSON schema files in the same directory
+    for file_name in os.listdir(schema_dir):
+        if file_name.endswith('.json') and file_name != os.path.basename(schema_path):
+            schemas[file_name] = load_schema(
+                os.path.join(schema_dir, file_name))
+
+    return schemas, schema_dir
+
+
+def validate_json(json_data, schema, schema_dir):
+    """Validate JSON data against the schema, resolving references."""
+    base_uri = f"file://{os.path.abspath(schema_dir)}/"
+    resolver = RefResolver(base_uri=base_uri, referrer=schema)
+    validator = Draft7Validator(schema, resolver=resolver)
+
+    errors = list(validator.iter_errors(json_data))
+
+    if not errors:
+        print("JSON is valid!")
+        return
+
+    for error in errors:
+        # Print error details
+        path_str = '/'.join(map(str, error.path))
+        print(f"Error at: {path_str}")
+        print(f"  Error message: {error.message}")
+        print(f"  Schema path: {'/'.join(map(str, error.schema_path))}")
+
+        # Print context for better understanding
+        context = get_error_context(json_data, error.path)
+        print(f"  Context: {json.dumps(context, indent=2)}")
+
+
+def get_error_context(data, path):
+    """Retrieve context from JSON data based on error path."""
+    for key in path:
+        if isinstance(data, list):
+            try:
+                data = data[key]
+            except IndexError:
+                return f"Index {key} out of range in list"
+        elif isinstance(data, dict):
+            data = data.get(key, {})
+        else:
+            return "Invalid path"
+    return data
+
+
+def read_json_from_file(file_path):
+    """Read JSON data from a file."""
+    with open(file_path) as f:
+        return json.load(f)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Validate a JSON string against a JSON Schema.",
+        usage="%(prog)s --schema <schema_file_path> --json <json_string_or_file>"
+    )
+    parser.add_argument('--schema', required=True,
+                        help="Path to the main JSON schema file.")
+    parser.add_argument('--json', required=True,
+                        help="The JSON string or file path to validate.")
+
+    args = parser.parse_args()
+
+    if not args.schema or not args.json:
+        parser.print_help()
+        exit(1)
+
+    try:
+        schemas, schema_dir = load_all_schemas(args.schema)
+        schema = schemas['main']
+    except FileNotFoundError:
+        print(f"Error: Schema file '{args.schema}' not found.")
+        exit(1)
+    except json.JSONDecodeError:
+        print(
+            f"Error: Failed to parse schema file '{args.schema}'. Ensure it is valid JSON.")
+        exit(1)
+
+    try:
+        if os.path.isfile(args.json):
+            json_data = read_json_from_file(args.json)
+        else:
+            json_data = json.loads(args.json)
+    except json.JSONDecodeError:
+        print("Error: Failed to parse JSON data. Ensure the JSON string or file contents are valid.")
+        exit(1)
+
+    validate_json(json_data, schema, schema_dir)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/schema_checker
+++ b/scripts/schema_checker
@@ -50,7 +50,6 @@ def validate_json(json_data, schema, schema_dir):
 
     if not errors:
         print("JSON is valid!")
-        return
 
     for error in errors:
         # Print error details

--- a/scripts/schema_checker
+++ b/scripts/schema_checker
@@ -1,15 +1,25 @@
 #!/usr/bin/env python3
 
+"""
+Script to check JSON responses against NMOS specification.
+
+Usage: ./schema_checker --schema <schema_file_path> --json <json_string_or_file>
+--json: Can either be file path or raw JSON.
+--schema: file path to schema to be checked.
+          Make sure the entire schema folder is checked out so dependencies can be resolved
+
+Requirements: ../requirements.txt
+"""
+
 import argparse
 import json
 import os
-import jsonschema
 from jsonschema import Draft7Validator, RefResolver
 
 
 def load_schema(file_path):
     """Load a JSON schema file."""
-    with open(file_path) as f:
+    with open(file_path, 'r', encoding='utf-8') as f:
         return json.load(f)
 
 
@@ -71,11 +81,12 @@ def get_error_context(data, path):
 
 def read_json_from_file(file_path):
     """Read JSON data from a file."""
-    with open(file_path) as f:
+    with open(file_path, 'r', encoding='utf-8') as f:
         return json.load(f)
 
 
 def main():
+    """Main functions parses args and runs schema check."""
     parser = argparse.ArgumentParser(
         description="Validate a JSON string against a JSON Schema.",
         usage="%(prog)s --schema <schema_file_path> --json <json_string_or_file>"
@@ -91,6 +102,7 @@ def main():
         parser.print_help()
         exit(1)
 
+    # Load json schemas
     try:
         schemas, schema_dir = load_all_schemas(args.schema)
         schema = schemas['main']
@@ -102,15 +114,18 @@ def main():
             f"Error: Failed to parse schema file '{args.schema}'. Ensure it is valid JSON.")
         exit(1)
 
+    # Try to open file, if its not a file path, use the raw input as json instead
     try:
         if os.path.isfile(args.json):
             json_data = read_json_from_file(args.json)
         else:
             json_data = json.loads(args.json)
     except json.JSONDecodeError:
-        print("Error: Failed to parse JSON data. Ensure the JSON string or file contents are valid.")
+        print("Error: Failed to parse JSON data."
+              "Ensure the JSON string or file contents are valid.")
         exit(1)
 
+    # Validate json and print potential mismatches
     validate_json(json_data, schema, schema_dir)
 
 


### PR DESCRIPTION
### Context:
This PR contains an updated version of the nmos-rs crate in which several adjustments are being made to mock the behavior of a Quip NMOS-node on Node-API version 1.3

### Changes:
- API:
  - Introduced option to upgrade to v1.3
- Config:
  - Made IP and port configurable
  - Added option to set a default registry
- Discovery / mDNS:
  - Skipped registries with unsupported API versions
- Lifecycle / registration:
  - Fixed heartbeats
  - Deleting and re-registering resources when encountering 200 upon registration
  - Reregister upon encountering 404 on heartbeat
  - Added ResourceUpdate functionality to handle updates to RegistrationAPI
- General:
  - Added debug messages
- Data model:
  - Added Capabilities
  - Added functionality to modify, remove and insert resources
Schema:
  - python script tool to check node-API responses against JSON schema specifications

### Current state:
- Multiple additions to the Node-API since v1.0 are still not implemented
  - interface_bindings, clocks, etc.

### Nmos-testing tool result:
| Name          | Duration (s)         | State                | Detail                                                                                                   |
|---------------|----------------------|----------------------|----------------------------------------------------------------------------------------------------------|
| __init__      | 0.101490             | <span style="color:black">Not Applicable</span> |                                                                                                          |
| set_up_tests  | 0.049736             | <span style="color:black">Not Applicable</span> |                                                                                                          |
| auto_node_1   | 0.003504             | <span style="color:green">Pass</span>         |                                                                                                          |
| auto_node_2   | 0.002626             | <span style="color:green">Pass</span>         |                                                                                                          |
| auto_node_3   | 0.004686             | <span style="color:green">Pass</span>         |                                                                                                          |
| auto_node_4   | 0.004140             | <span style="color:green">Pass</span>         |                                                                                                          |
| auto_node_5   | 0.002715             | <span style="color:green">Pass</span>         |                                                                                                          |
| auto_node_6   | 0.010849             | <span style="color:green">Pass</span>         |                                                                                                          |
| auto_node_7   | 0.066161             | <span style="color:green">Pass</span>         |                                                                                                          |
| auto_node_8   | 0.006717             | <span style="color:green">Pass</span>         |                                                                                                          |
| auto_node_9   | 0.005940             | <span style="color:green">Pass</span>         |                                                                                                          |
| auto_node_10  | 0.002125             | <span style="color:red">Fail</span>            | Error for {'receiverId': '32eaf63e-f826-4a8d-ac01-9ee939b8adba'}: 'Access-Control-Allow-Headers' not in CORS headers: {'access-control-allow-origin': '*', 'vary': 'origin, access-control-request-method, access-control-request-headers', 'access-control-allow-methods': 'GET,POST', 'content-length': '0', 'date': 'Thu, 26 Sep 2024 13:52:16 GMT'} |
| auto_node_11  | 0.003891             | <span style="color:green">Pass</span>         |                                                                                                          |
| auto_node_12  | 0.004576             | <span style="color:green">Pass</span>         |                                                                                                          |
| auto_node_13  | 0.023354             | <span style="color:green">Pass</span>         |                                                                                                          |
| auto_node_14  | 0.007765             | <span style="color:green">Pass</span>         |                                                                                                          |
| auto_node_15  | 0.049682             | <span style="color:green">Pass</span>         |                                                                                                          |
| auto_node_16  | 0.012542             | <span style="color:green">Pass</span>         |                                                                                                          |
| auto_node_17  | 0.000009             | <span style="color:black">Test Disabled</span> | This test is only performed when an API supports Authorization and 'ENABLE_AUTH' is True                 |
| auto_node_18  | 0.000003             | <span style="color:black">Test Disabled</span> | This test is only performed when an API supports Authorization and 'ENABLE_AUTH' is True                 |
| auto_node_19  | 0.000026             | <span style="color:black">Test Disabled</span> | This test is only performed when an API supports Authorization and 'ENABLE_AUTH' is True                 |
| auto_node_20  | 0.000029             | <span style="color:black">Test Disabled</span> | This test is only performed when an API supports Authorization and 'ENABLE_AUTH' is True                 |
| auto_node_21  | 0.000027             | <span style="color:black">Test Disabled</span> | This test is only performed when an API supports Authorization and 'ENABLE_AUTH' is True                 |
| auto_node_22  | 0.000023             | <span style="color:black">Test Disabled</span> | This test is only performed when an API supports Authorization and 'ENABLE_AUTH' is True                 |
| auto_node_23  | 0.000006             | <span style="color:black">Test Disabled</span> | This test is only performed when an API supports Authorization and 'ENABLE_AUTH' is True                 |
| test_01       | 29.233571            | <span style="color:green">Pass</span>         |                                                                                                          |
| test_01_01    | 0.000014             | <span style="color:green">Pass</span>         |                                                                                                          |
| test_02       | 0.000006             | <span style="color:black">Test Disabled</span> | This test cannot be performed when ENABLE_DNS_SD is False or DNS_SD_MODE is not 'unicast'              |
| test_02_01    | 0.000007             | <span style="color:black">Test Disabled</span> | This test cannot be performed when ENABLE_DNS_SD is False or DNS_SD_MODE is not 'unicast'              |
| test_03       | 0.000191             | <span style="color:green">Pass</span>         |                                                                                                          |
| test_03_01    | 0.000012             | <span style="color:green">Pass</span>         |                                                                                                          |
| test_04       | 0.000025             | <span style="color:green">Pass</span>         |                                                                                                          |
| test_05       | 0.000018             | <span style="color:yellow">Warning</span>     | Heartbeat POST did not contain a valid Content-Length header.                                           |
| test_07       | 0.000012             | <span style="color:green">Pass</span>         |                                                                                                          |
| test_07_01    | 0.000017             | <span style="color:green">Pass</span>         |                                                                                                          |
| test_08       | 0.000072             | <span style="color:green">Pass</span>         |                                                                                                          |
| test_08_01    | 0.000015             | <span style="color:green">Pass</span>         |                                                                                                          |
| test_09       | 0.000044             | <span style="color:green">Pass</span>         |                                                                                                          |
| test_09_01    | 0.000019             | <span style="color:green">Pass</span>         |                                                                                                          |
| test_10       | 0.000043             | <span style="color:green">Pass</span>         |                                                                                                          |
| test_10_01    | 0.000017             | <span style="color:green">Pass</span>         |                                                                                                          |
| test_11       | 0.000012             | <span style="color:green">Pass</span>         |                                                                                                          |
| test_11_01    | 0.000014             | <span style="color:green">Pass</span>         |                                                                                                          |
| test_12       | 0.000007             | <span style="color:black">Test Disabled</span> | This test is disabled for Nodes >= v1.3                                                                 |
| test_12_01    | 32.814048            | <span style="color:green">Pass</span>         |                                                                                                          |
| test_13       | 0.834196             | <span style="color:red">Fail</span>           | Receiver target PUT did not produce a 202 (or 501) response code: 404. Please ensure SDP_PREFERENCES match the node under test. |
| test_14       | 0.007437             | <span style="color:red">Fail</span>           | Receiver target PUT did not produce a 202 (or 501) response code: 404. Please ensure SDP_PREFERENCES match the node under test. |
| test_15       | 0.000019             | <span style="color:red">Fail</span>           | Node never made contact with registry 1 advertised on port 5103                                           |
| test_16       | 0.000008             | <span style="color:red">Fail</span>           | Node never made contact with registry 1 advertised on port 5103                                           |
| test_16_01    | 0.000007             | <span style="color:yellow">Warning</span>     | Node never made contact with registry 5 advertised on port 5106                                           |
| test_17       | 0.018984             | <span style="color:green">Pass</span>         |                                                                                                          |
| test_17_01    | 0.009474             | <span style="color:yellow">Warning</span>     | One or more Devices do not have references to any of their Senders or Receivers. (The 'senders' and 'receivers' attributes are deprecated
